### PR TITLE
Added functionallity for skipping arguments in key generation

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ var cache = {
         var self = thisobj || this;
         var args = Array.prototype.slice.apply(arguments);
         var callback = args.pop();
-        var key,data;
+        var key,data,keyArgs;
 
         if (typeof callback !== 'function') {
           throw new Error('last argument to ' + fname + ' should be a function');


### PR DESCRIPTION
wrap, warmup and invalidate can be called with an extra argument skipArgs. skipArgs is the array of indexes for which arguments should  be skipped for key generation