### PR TITLE
feat: Upgrade lru-cache to v11 and optimize obcache

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Usage
 var obcache = require('obcache');
 
 // create a cache with max 10000 items and a TTL of 300 seconds
-var cache = new obcache.Create({ max: 10000, maxAge: 300 });
+var cache = new obcache.Create({ max: 10000, ttl: 300000 }); // maxAge is now ttl, and in milliseconds
+// If no options for max, maxSize, or ttl are provided, the cache will default to max: 1000 items.
 ```
 
 Then wrap your original function like this
@@ -33,14 +34,17 @@ API
 ---
 
 ### obcache.Create
-Creates a new cache and returns it
+Creates a new cache and returns it.
+`obcache.Create(options)` now requires `options` to include `max`, `ttl`, or `maxSize`. If none of these are provided, a default of `max: 1000` items will be used.
+Note: `lru-cache` v11 uses `ttl` in milliseconds instead of `maxAge` in seconds.
 
 ### cache.wrap 
 Wraps a given function and returns a cached version of it.
-Functions to be wrapped must have a callback function as the last argument. The callback function is expected to recieve 2 arguments - err and data. data gets stored in the cache.
+Functions to be wrapped must have a callback function as the last argument. The callback function is expected to recieve 2 arguments - err and data. `data` gets stored in the cache.
+`obcache` now correctly supports caching and retrieving `undefined` values.
 Sometimes, you may want to use a different value of this inside the caller function. cache.wrap has an optional second argument which becomes the this object when calling the original function.
 
-The first n-1 arguments are used to create the key. Subsequently, when the wrapped function is called with the same n arguments, it would lookup the key in LRU, and if found, call the callback with the associated data. It is expected that the callback will never modified the returned data, as any modifications of the original will change the object in cache. 
+The first n-1 arguments are used to create the key. Subsequently, when the wrapped function is called with the same n arguments, it would lookup the key in LRU, and if found, call the callback with the associated data. It is expected that the callback will never modified the returned data, as any modifications of the original will change the object in cache.
 
 ### cache.debug
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 "use strict";
 
-var LRU = require('lru-cache');
+var { LRUCache } = require('lru-cache');
 var sigmund = require('sigmund');
+
+const UNDEFINED_VALUE_SIGIL = Symbol('obcache_undefined_value');
 
 function keygen(name,args) {
   var input = { f: name, a: args };
@@ -20,8 +22,13 @@ var cache = {
    * @param {Object} LRU Options
    *
    **/
-  Create: function(options) {
-    var lru = LRU(options);
+  Create: function(userOptions) {
+    let lruOptions = userOptions;
+    if (!userOptions || (userOptions.max === undefined && userOptions.maxSize === undefined && userOptions.ttl === undefined)) {
+      lruOptions = userOptions ? { ...userOptions } : {}; // Shallow copy if userOptions exists
+      lruOptions.max = 1000; // Default max if no size/ttl option is set
+    }
+    var lru = new LRUCache(lruOptions);
     var anonFnId = 0;
     this.lru = lru;
     /**
@@ -46,7 +53,7 @@ var cache = {
         var self = thisobj || this;
         var args = Array.prototype.slice.apply(arguments);
         var callback = args.pop();
-        var key,data;
+        var key;
 
         if (typeof callback !== 'function') {
           throw new Error('last argument to ' + fname + ' should be a function');
@@ -54,30 +61,36 @@ var cache = {
 
         key = keygen(fname,args);
 
-        data = lru.get(key);
-        // while LRU is sync - we need to support redis like stores in future, which won't be sync, 
-        // and hence this function.
-        (function(err, data) {
-          if (!err && data) {
-            return callback.call(self,err,data); // found in cache
-          }
-
+        var cachedValue = lru.get(key);
+        if (cachedValue !== undefined) { // Means key was found
+          const finalValue = cachedValue === UNDEFINED_VALUE_SIGIL ? undefined : cachedValue;
+          // For consistent async behavior, you might use process.nextTick here
+          // process.nextTick(() => callback.call(self, null, finalValue));
+          return callback.call(self, null, finalValue);
+        } else {
+          // Cache miss
           args.push(function(err,res) {
-            if (!err) { 
-              lru.set(key,res);
+            if (!err) {
+              lru.set(key, res === undefined ? UNDEFINED_VALUE_SIGIL : res);
             }
             callback.call(self,err,res);
           });
 
           fn.apply(self,args);
-        }(null,data));
-
+        }
       };
     };
 
     // re-export keys and values
-    this.keys = this.lru.keys.bind(this.lru);
-    this.values = this.lru.values.bind(this.lru);
+    // Note: lru-cache v11.x still has keys() and values() but they return iterators.
+    // Depending on how these are used downstream, this might require adjustment
+    // if array-like behavior was expected. For now, binding them as is.
+    if (typeof this.lru.keys === 'function') {
+      this.keys = this.lru.keys.bind(this.lru);
+    }
+    if (typeof this.lru.values === 'function') {
+      this.values = this.lru.values.bind(this.lru);
+    }
   },
 
   debug: require('./debug')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "obcache",
+  "version": "0.0.4",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "obcache",
+      "version": "0.0.4",
+      "license": "BSD",
+      "dependencies": {
+        "benchmark": "^2.1.4",
+        "lru-cache": "^11.1.0",
+        "sigmund": "~1.0.0"
+      }
+    },
+    "node_modules/benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "dependencies": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lru-cache": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
+    },
+    "node_modules/sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "author": "Qasim Zaidi",
   "license": "BSD",
   "dependencies": {
-    "sigmund": "~1.0.0",
-    "lru-cache": "~2.3.1"
+    "benchmark": "^2.1.4",
+    "lru-cache": "^11.1.0",
+    "sigmund": "~1.0.0"
   }
 }

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -23,7 +23,7 @@ var suite = new Benchmark.Suite();
     console.log(String(event.target));
   })
   .on('complete', function() {
-    console.log('Fastest is ' + this.filter('fastest').pluck('name'));
+    console.log('Fastest is ' + this.filter('fastest').map('name'));
   })
   .run({ async: true });
 }());


### PR DESCRIPTION
This commit introduces several improvements to the obcache implementation:

1.  Upgraded `lru-cache` from v2.3.1 to v11.1.0.
    - Adapted `obcache` to use the new `LRUCache` constructor and named import.
    - Implemented a default `max: 1000` items in `obcache.Create` if no `max`, `maxSize`, or `ttl` option is provided by you, to comply with `lru-cache` v11's requirement for a cache bound.
    - Addressed `lru-cache` v11's behavior of treating `set(key, undefined)` as a delete operation. `obcache` now uses an internal sigil to allow `undefined` values to be explicitly cached and retrieved.

2.  Simplified the `wrap` function in `index.js` by removing an unnecessary IIFE, improving code readability. The behavior of invoking callbacks synchronously on a cache hit is maintained.

3.  Updated `README.md` to inform you about:
    - The new default cache sizing behavior.
    - The need to use `ttl` (in milliseconds) instead of `maxAge` (in seconds) if passing time-based eviction options to `lru-cache` via `obcache`.
    - The confirmed support for caching `undefined` values.

4.  The `test/benchmark.js` script was updated to use `.map` instead of the deprecated `.pluck` method from the `benchmark` library.

The basic tests (`test/basic.js`) pass, confirming core functionality. Benchmarks (`test/benchmark.js`) indicate an acceptable overhead for the caching mechanism, which is expected to provide significant performance gains for non-trivial functions.